### PR TITLE
Bug Fix: vfatmask was only set for the perchannel case

### DIFF
--- a/src/calibration_routines.cpp
+++ b/src/calibration_routines.cpp
@@ -618,22 +618,27 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
         case 3:
         {
             // Loop over ohMask and retrieve VFAT masks
-            if( ch != 128){
-                for (int ohN = 0; ohN < 12; ++ohN) {
-                    if ((ohMask >> ohN) & 0x1) {
-                        vfatmask[ohN] = getOHVFATMaskLocal(la, ohN);
-                        //If ch!=128 store the original channel mask settings
+            for (int ohN = 0; ohN < 12; ++ohN)
+            {
+                if ((ohMask >> ohN) & 0x1)
+                {
+                    vfatmask[ohN] = getOHVFATMaskLocal(la, ohN);
+                    LOGGER->log_message(LogManager::INFO, stdsprintf("VFAT Mask for OH%i Determined to be 0x%x",ohN,vfatmask[ohN]));
+
+                    //If ch!=128 store the original channel mask settings
+                    if( ch != 128)
+                    {
                         //Then mask all other channels except for channel ch
-                        uint32_t notmask = ~vfatmask[ohN];
-                            for(int vfat = 0; vfat < 24; ++vfat){
-                                //Skip this vfat if it's masked
-                                if ( !( (notmask >> vfat) & 0x1)) continue;
-                                origVFATmasks[ohN][vfat] = setSingleChanMask(ohN,vfat,ch,la);
-                            } //End loop over all vfats
-                        //origVFATmasks[ohN] = map_chanOrigMask;
-                    }
-                } //End loop over optohybrids
-            } //End loop over vfat channels
+                        uint32_t notmask = ~vfatmask[ohN] & 0xFFFFFF;
+                        for(int vfat = 0; vfat < 24; ++vfat)
+                        {
+                            //Skip this vfat if it's masked
+                            if ( !( (notmask >> vfat) & 0x1)) continue;
+                            origVFATmasks[ohN][vfat] = setSingleChanMask(ohN,vfat,ch,la);
+                        } //End loop over all vfats
+                    } //End loop over vfat channels
+                } //End case this OH is not masked
+            } //End loop over optohybrids
 
             //Get the SBIT Rate Monitor Address
             uint32_t ohTrigRateAddr[12][25]; //idx 0->23 VFAT counters; idx 24 overall rate
@@ -664,7 +669,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
                 //Set the scan register value
                 for (int ohN = 0; ohN < 12; ++ohN) {
                     if ((ohMask >> ohN) & 0x1) {
-                        uint32_t notmask = ~vfatmask[ohN];
+                        uint32_t notmask = ~vfatmask[ohN] & 0xFFFFFF;
                         for(int vfat=0; vfat<24; ++vfat){
                             if ( !( (notmask >> vfat) & 0x1)) continue;
                             sprintf(regBuf,"GEM_AMC.OH.OH%i.GEB.VFAT%i.CFG_%s",ohN,vfat,scanReg.c_str());
@@ -695,7 +700,7 @@ void sbitRateScanParallelLocal(localArgs *la, uint32_t *outDataDacVal, uint32_t 
             if( ch != 128) {
                 for (int ohN = 0; ohN < 12; ++ohN) {
                     if ((ohMask >> ohN) & 0x1) {
-                        uint32_t notmask = ~vfatmask[ohN];
+                        uint32_t notmask = ~vfatmask[ohN] & 0xFFFFFF;
                         for(int vfat=0; vfat<24; ++vfat){
                             if ( !( (notmask >> vfat) & 0x1)) continue;
                             applyChanMask(origVFATmasks[ohN][vfat], la);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `vfatmask` array was initialized to `0x0` for all OH's and it was only being filled if the per channel case was being performed (e.g. `ch != 128`).

This caused VFATs that should be masked to be queried.  I've resolved this bug.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running scans.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
